### PR TITLE
Implement notification toggle handling

### DIFF
--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -79,6 +79,15 @@ export const scheduleReminders = async (
   }
 };
 
+export const cancelScheduledReminders = async () => {
+  try {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+  } catch (error) {
+    console.warn('Failed to cancel scheduled notifications:', error);
+    throw error;
+  }
+};
+
 const calculateReminderTimes = (
   wakeTime: string,
   sleepTime: string,


### PR DESCRIPTION
## Summary
- add a dedicated notification toggle handler that requests permission, schedules reminders, or cancels them based on the switch state
- persist the switch state only after async work completes and prevent duplicate toggles while processing
- ensure reminder scheduling uses the latest profile wake/sleep times and calculated daily goal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6a4e7668832cb3f351a9eeeb49d8