### PR TITLE
Fix duplicate headers on settings screens

### DIFF
--- a/app/(tabs)/settings/_layout.tsx
+++ b/app/(tabs)/settings/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+
+export default function SettingsStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a settings stack layout that disables the default React Navigation header so only the custom header renders

## Testing
- npm run lint *(fails: expo lint expects a Yarn lockfile in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6a721930832ca315dd475aef6dd2