### PR TITLE
Specify date trigger type for scheduled notifications

### DIFF
--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,5 +1,6 @@
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as Notifications from 'expo-notifications';
+import { SchedulableTriggerInputTypes } from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import { Platform } from 'react-native';
 
@@ -122,6 +123,7 @@ export const scheduleNextReminder = async (
           sound: true,
         },
         trigger: {
+          type: SchedulableTriggerInputTypes.DATE,
           date: scheduledTime,
         },
       });
@@ -209,6 +211,7 @@ export const scheduleReminders = async (
           priority: Notifications.AndroidNotificationPriority.HIGH,
         },
         trigger: {
+          type: SchedulableTriggerInputTypes.DATE,
           date: scheduledTime,
           channelId: NOTIFICATION_CHANNEL_ID,
         },


### PR DESCRIPTION
## Summary
- ensure date-based notification scheduling specifies the DATE trigger type for Expo schedulable triggers

## Testing
- npm run lint *(fails: expo lint expects yarn lock entries in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf75634374832c907c5423b39b1b96