### PR TITLE
オンボーディングでリマインダーのスケジュール引数をオプション化

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -17,7 +17,7 @@ import { scheduleNextReminder } from '../lib/notifications';
 import { useHydrationStore } from '../stores/hydrationStore';
 
 export default function OnboardingScreen() {
-  const { setUserProfile, setOnboarded } = useHydrationStore();
+  const { setUserProfile, setOnboarded, settings } = useHydrationStore();
   
   const [weight, setWeight] = useState('');
   const [height, setHeight] = useState('');
@@ -56,7 +56,14 @@ export default function OnboardingScreen() {
 
       // Schedule notifications
       const goal = calculateDailyGoal(profile);
-      await scheduleNextReminder(wakeTime, sleepTime, goal.targetMl);
+      await scheduleNextReminder({
+        wakeTime,
+        sleepTime,
+        targetMl: goal.targetMl,
+        consumedMl: 0,
+        reminderCount: 8,
+        userSnoozeMin: settings.snoozeMinutes,
+      });
 
       // Force reload to show home screen
       router.replace('/(tabs)');


### PR DESCRIPTION
## Summary
- オンボーディング完了時に通知スケジュールへ渡すデータをオプションオブジェクトに変更
- 起床・就寝時刻や目標量に加えて初期摂取量0と既定のリマインド回数、スヌーズ設定を指定

## Testing
- npm run lint *(fails: expo lint が Yarn の lockfile を認識できず失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbbf24008832cbad88e42c6ec1d12