### PR TITLE
Refine snooze notification cancellation

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
+import * as Notifications from 'expo-notifications';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { MainHeader } from '../../components/main-header';
 import { ProgressRing } from '../../components/ui/ProgressRing';
@@ -78,6 +79,14 @@ export default function HomeScreen() {
       try {
         await cancelSnoozeReminders();
         console.log('Snooze reminders cancelled after water intake');
+
+        const remainingNotifications = await Notifications.getAllScheduledNotificationsAsync();
+        const remainingMorningWakeups = remainingNotifications.filter(
+          (notification) => notification.content.data?.type === 'morning_wakeup'
+        );
+        console.log(
+          `Remaining morning wakeup notifications after water intake: ${remainingMorningWakeups.length}`
+        );
       } catch (error) {
         console.error('Failed to cancel snooze reminders:', error);
       }


### PR DESCRIPTION
## Summary
- scope snooze cancellations to notifications tagged with the snooze category and type
- enrich snooze scheduling metadata so the reminders can be identified without touching other scheduled notifications
- log the remaining morning wakeup reminders after cancelling snooze alerts from the home screen quick-add flow

## Testing
- npm run lint *(fails: expo lint internally invokes Yarn which expects a lockfile entry for the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbc068e64832c9860e3e094ef29f3