### PR TITLE
Refactor onboarding profile construction

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { saveUserProfile } from '../lib/database';
+import { buildUserProfile } from '../lib/profile';
 import { useHydrationStore } from '../stores/hydrationStore';
 
 export default function OnboardingScreen() {
@@ -24,20 +25,12 @@ export default function OnboardingScreen() {
 
   // 自動保存機能
   const autoSave = useCallback(async () => {
-    if (!weight || isNaN(Number(weight)) || Number(weight) <= 0) return;
+    const profile = buildUserProfile(weight, height);
+    if (!profile) {
+      return;
+    }
 
     try {
-      const profile = {
-        id: Date.now().toString(),
-        weightKg: Number(weight),
-        sex: 'male', // デフォルト値
-        heightCm: height ? Number(height) : undefined,
-        activityLevel: 'medium', // デフォルト値
-        wakeTime: '07:00', // デフォルト値
-        sleepTime: '23:00', // デフォルト値
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      };
-
       await saveUserProfile(profile);
       setUserProfile(profile);
       console.log('Profile auto-saved during onboarding');
@@ -58,7 +51,8 @@ export default function OnboardingScreen() {
   }, [weight, height, autoSave]);
 
   const handleComplete = async () => {
-    if (!weight || isNaN(Number(weight)) || Number(weight) <= 0) {
+    const profile = buildUserProfile(weight, height);
+    if (!profile) {
       Alert.alert('エラー', '体重を正しく入力してください');
       return;
     }
@@ -66,20 +60,10 @@ export default function OnboardingScreen() {
     setIsLoading(true);
 
     try {
-      const profile = {
-        id: Date.now().toString(),
-        weightKg: Number(weight),
-        sex: 'male', // デフォルト値
-        heightCm: height ? Number(height) : undefined,
-        activityLevel: 'medium', // デフォルト値
-        wakeTime: '07:00', // デフォルト値
-        sleepTime: '23:00', // デフォルト値
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      };
 
       // Save to database
       await saveUserProfile(profile);
-      
+
       // Update store
       setUserProfile(profile);
       setOnboarded(true);

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,46 @@
+import { UserProfile } from '../types';
+
+const isValidNumber = (value: string): boolean => {
+  if (!value.trim()) {
+    return false;
+  }
+
+  const parsed = Number(value);
+  return !Number.isNaN(parsed) && parsed > 0;
+};
+
+const parseOptionalNumber = (value: string): number | undefined => {
+  if (!value.trim()) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return parsed;
+};
+
+export const buildUserProfile = (
+  weight: string,
+  height: string
+): UserProfile | null => {
+  if (!isValidNumber(weight)) {
+    return null;
+  }
+
+  const weightKg = Number(weight);
+  const heightCm = parseOptionalNumber(height);
+
+  return {
+    id: Date.now().toString(),
+    weightKg,
+    sex: 'male',
+    heightCm,
+    activityLevel: 'medium',
+    wakeTime: '07:00',
+    sleepTime: '23:00',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  };
+};


### PR DESCRIPTION
## Summary
- add a shared `buildUserProfile` helper to encapsulate profile defaults and validation
- update onboarding auto-save and completion handlers to reuse the helper when persisting a profile

## Testing
- npm run lint *(fails: existing lint warnings/errors in settings screens)*
- npx eslint app/onboarding.tsx lib/profile.ts
- npx tsc --noEmit *(fails: existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdeb3c888832ca77548457e55b41c