### PR TITLE
Refactor loading UI into shared FullScreenLoader component

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,9 +2,9 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Text, View } from 'react-native';
 import 'react-native-reanimated';
 
+import { FullScreenLoader } from '@/components/FullScreenLoader';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { initDatabase } from '../lib/database';
 import { useHydrationStore } from '../stores/hydrationStore';
@@ -40,12 +40,10 @@ export default function RootLayout() {
   // Show loading screen while initializing
   if (isLoading) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#F2F2F7' }}>
-        <ActivityIndicator size="large" color="#007AFF" />
-        <Text style={{ marginTop: 16, fontSize: 16, color: '#8E8E93' }}>
-          読み込み中...
-        </Text>
-      </View>
+      <FullScreenLoader
+        message="アプリを初期化しています..."
+        spinnerAccessibilityLabel="アプリを初期化しています"
+      />
     );
   }
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Text, View } from 'react-native';
+import { FullScreenLoader } from '@/components/FullScreenLoader';
 
 export default function IndexScreen() {
   const [isNavigating, setIsNavigating] = useState(false);
@@ -43,12 +43,5 @@ export default function IndexScreen() {
     return () => clearTimeout(timeoutId);
   }, [isNavigating]);
 
-  return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#F2F2F7' }}>
-      <ActivityIndicator size="large" color="#007AFF" />
-      <Text style={{ marginTop: 16, fontSize: 16, color: '#8E8E93' }}>
-        読み込み中...
-      </Text>
-    </View>
-  );
+  return <FullScreenLoader />;
 }

--- a/components/FullScreenLoader.tsx
+++ b/components/FullScreenLoader.tsx
@@ -1,0 +1,50 @@
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+export const FULL_SCREEN_LOADER_COLORS = {
+  background: '#F2F2F7',
+  spinner: '#007AFF',
+  text: '#1C1C1E',
+} as const;
+
+export const FULL_SCREEN_LOADER_MESSAGES = {
+  defaultMessage: '読み込み中...',
+  defaultAccessibilityLabel: '読み込み中',
+} as const;
+
+export type FullScreenLoaderProps = {
+  message?: string;
+  spinnerAccessibilityLabel?: string;
+};
+
+export function FullScreenLoader({
+  message = FULL_SCREEN_LOADER_MESSAGES.defaultMessage,
+  spinnerAccessibilityLabel = FULL_SCREEN_LOADER_MESSAGES.defaultAccessibilityLabel,
+}: FullScreenLoaderProps) {
+  return (
+    <View style={styles.container} accessibilityRole="alert" accessibilityLiveRegion="polite">
+      <ActivityIndicator
+        size="large"
+        color={FULL_SCREEN_LOADER_COLORS.spinner}
+        accessibilityLabel={spinnerAccessibilityLabel}
+      />
+      <Text style={styles.message}>{message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: FULL_SCREEN_LOADER_COLORS.background,
+    paddingHorizontal: 24,
+  },
+  message: {
+    marginTop: 16,
+    fontSize: 16,
+    color: FULL_SCREEN_LOADER_COLORS.text,
+    textAlign: 'center',
+  },
+});
+


### PR DESCRIPTION
## Summary
- add a configurable FullScreenLoader shared component with centralized colors and messaging
- replace duplicated inline loading markup in the root layout and index screen with the shared loader
- expose loader defaults so other screens can reuse consistent styles and accessibility labels

## Testing
- yarn lint *(fails: existing lint errors in app/(tabs)/settings files unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdeb1eb94832c9cfee7554622e09d