### PR TITLE
Ensure notification channel exists before scheduling

### DIFF
--- a/lib/notifications/channels.ts
+++ b/lib/notifications/channels.ts
@@ -1,0 +1,45 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+import { NOTIFICATION_CHANNEL_ID } from './constants';
+
+let channelSetupPromise: Promise<void> | null = null;
+
+const createChannelIfNeeded = async (): Promise<void> => {
+  const existingChannel = await Notifications.getNotificationChannelAsync(
+    NOTIFICATION_CHANNEL_ID
+  );
+
+  if (existingChannel) {
+    return;
+  }
+
+  await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL_ID, {
+    name: 'Hydration Reminders',
+    description: 'Water intake reminders and morning wake-up alerts.',
+    importance: Notifications.AndroidImportance.HIGH,
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    sound: 'default',
+    enableLights: true,
+    enableVibrate: true,
+    vibrationPattern: [0, 250, 250, 250],
+  });
+};
+
+export const ensureNotificationChannel = async (): Promise<void> => {
+  if (Platform.OS !== 'android') {
+    return;
+  }
+
+  if (!channelSetupPromise) {
+    channelSetupPromise = createChannelIfNeeded();
+  }
+
+  try {
+    await channelSetupPromise;
+  } catch (error) {
+    channelSetupPromise = null;
+    console.warn('Failed to ensure notification channel:', error);
+    throw error;
+  }
+};

--- a/lib/notifications/legacy.ts
+++ b/lib/notifications/legacy.ts
@@ -2,6 +2,7 @@ import * as Notifications from 'expo-notifications';
 import { SchedulableTriggerInputTypes } from 'expo-notifications';
 
 import { NOTIFICATION_CHANNEL_ID } from './constants';
+import { ensureNotificationChannel } from './channels';
 import { waitFor } from './helpers';
 import { ensureNotificationsEnabled } from './permissions';
 
@@ -21,6 +22,8 @@ export const scheduleReminders = async (
 
     await Notifications.cancelAllScheduledNotificationsAsync();
     await waitFor(500);
+
+    await ensureNotificationChannel();
 
     const times = calculateReminderTimes(wakeTime, sleepTime, reminderCount);
     const maxNotifications = Math.min(times.length, 64);

--- a/lib/notifications/planning.ts
+++ b/lib/notifications/planning.ts
@@ -3,6 +3,7 @@ import { SchedulableTriggerInputTypes } from 'expo-notifications';
 
 import { planNextReminder, ReminderPlanResult } from '../reminderPlanner';
 import { NOTIFICATION_CHANNEL_ID } from './constants';
+import { ensureNotificationChannel } from './channels';
 import { parseTimeToDate } from './helpers';
 import { ensureNotificationsEnabled } from './permissions';
 
@@ -49,6 +50,8 @@ export const scheduleNextReminderInternal = async (
   }
 
   const { title, body } = buildNotificationMessage(plan);
+
+  await ensureNotificationChannel();
 
   await Notifications.scheduleNotificationAsync({
     content: {


### PR DESCRIPTION
## Summary
- add a notification channel helper that creates the hydration reminder channel on Android when needed
- call the helper from both the adaptive and legacy scheduling paths so scheduling no longer fails when a channel ID is provided

## Testing
- npm run lint *(fails: existing lint warnings and duplicate style keys in app screens)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe21f958c832c92b257d24b10a037